### PR TITLE
Use an arrow instead of hand to signify a PR

### DIFF
--- a/src/FormatUtil.ts
+++ b/src/FormatUtil.ts
@@ -34,7 +34,7 @@ export class FormatUtil {
             case "Issue":
                 return "📝";
             case "PullRequest":
-                return "✋"; // What should we do about this?
+                return "⤵";
             default: 
                 return "🔔";
         }


### PR DESCRIPTION
Use ⤵instead of :hand:.

Looks better in a client with proper emoji support:

![image](https://user-images.githubusercontent.com/1342360/75031204-a26ef200-549d-11ea-9231-3775523c27a1.png)
