### PR TITLE
Add support for handling generic webhooks

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -32,7 +32,13 @@ gitlab:
 jira:
   # Configure this to enable Jira support
   #
-  null
+  webhook:
+    secret: secrettoken
+generic:
+  # (Optional) Support for generic webhook events. `allowJsTransformationFunctions` will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments
+  #
+  enabled: false
+  allowJsTransformationFunctions: false
 webhook:
   # HTTP webhook listener options
   #

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -9,7 +9,7 @@ bridge:
   port: 9993
   bindAddress: 127.0.0.1
 github:
-  # (Optional) Configure this to enable support for GitHub
+  # (Optional) Configure this to enable GitHub support
   #
   installationId: 6854059
   auth:
@@ -22,13 +22,17 @@ github:
   webhook:
     secret: secrettoken
 gitlab:
-  # (Optional) Configure this to enable support for GitLab
+  # (Optional) Configure this to enable GitLab support
   #
   instances:
     gitlab.com:
       url: https://gitlab.com
   webhook:
     secret: secrettoken
+jira:
+  # Configure this to enable Jira support
+  #
+  null
 webhook:
   # HTTP webhook listener options
   #

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -30,7 +30,7 @@ gitlab:
   webhook:
     secret: secrettoken
 jira:
-  # Configure this to enable Jira support
+  # (Optional) Configure this to enable Jira support
   #
   webhook:
     secret: secrettoken

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -119,7 +119,7 @@ export class BridgeConfig {
     public readonly github?: BridgeConfigGitHub;
     @configKey("Configure this to enable GitLab support", true)
     public readonly gitlab?: BridgeConfigGitLab;
-    @configKey("Configure this to enable Jira support")
+    @configKey("Configure this to enable Jira support", true)
     public readonly jira?: BridgeConfigJira;
     @configKey("Support for generic webhook events. `allowJsTransformationFunctions` will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments", true)
     public readonly generic?: BridgeGenericWebhooksConfig;
@@ -140,6 +140,7 @@ export class BridgeConfig {
         }
         this.gitlab = configData.gitlab;
         this.jira = configData.jira;
+        this.generic = configData.generic;
         this.webhook = configData.webhook;
         this.passFile = configData.passFile;
         assert.ok(this.webhook);

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -45,6 +45,11 @@ interface BridgeConfigJira {
     };
 }
 
+interface BridgeGenericWebhooksConfig {
+    enabled: boolean;
+    allowJsTransformationFunctions?: boolean;
+}
+
 interface BridgeWidgetConfig {
     port: number;
     addToAdminRooms: boolean;
@@ -95,6 +100,7 @@ interface BridgeConfigRoot {
     jira?: BridgeConfigJira;
     bot?: BridgeConfigBot;
     widgets?: BridgeWidgetConfig;
+    generic?: BridgeGenericWebhooksConfig;
 }
 
 export class BridgeConfig {
@@ -115,6 +121,8 @@ export class BridgeConfig {
     public readonly gitlab?: BridgeConfigGitLab;
     @configKey("Configure this to enable Jira support")
     public readonly jira?: BridgeConfigJira;
+    @configKey("Support for generic webhook events. `allowJsTransformationFunctions` will allow users to write short transformation snippets in code, and thus is unsafe in untrusted environments", true)
+    public readonly generic?: BridgeGenericWebhooksConfig;
     @configKey("Define profile information for the bot user", true)
     public readonly bot?: BridgeConfigBot;
     @configKey("EXPERIMENTAL support for complimentary widgets", true)

--- a/src/Config/Defaults.ts
+++ b/src/Config/Defaults.ts
@@ -58,6 +58,15 @@ const DefaultConfig = new BridgeConfig({
         webhook: {
             secret: "secrettoken",
         }
+    },
+    jira: {
+        webhook: {
+            secret: 'secrettoken'
+        }
+    },
+    generic: {
+        enabled: false,
+        allowJsTransformationFunctions: false,
     }
 }, {});
 

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -34,8 +34,9 @@ export class GenericHookConnection implements IConnection {
     constructor(public readonly roomId: string,
         private state: GenericHookConnectionState,
         private readonly stateKey: string,
-        private messageClient: MessageSenderClient) {
-            if (state.transformationFunction) {
+        private messageClient: MessageSenderClient,
+        private readonly allowJSTransformation: boolean = false) {
+            if (state.transformationFunction && allowJSTransformation) {
                 this.transformationFunction = new Script(state.transformationFunction);
             }
         }
@@ -46,7 +47,7 @@ export class GenericHookConnection implements IConnection {
 
     public async onStateUpdate(stateEv: MatrixEvent<unknown>) {
         const state = stateEv.content as GenericHookConnectionState;
-        if (state.transformationFunction) {
+        if (state.transformationFunction && this.allowJSTransformation) {
             try {
                 this.transformationFunction = new Script(state.transformationFunction);
             } catch (ex) {

--- a/src/Connections/GenericHook.ts
+++ b/src/Connections/GenericHook.ts
@@ -1,0 +1,86 @@
+import { IConnection } from "./IConnection";
+import { Appservice } from "matrix-bot-sdk";
+import LogWrapper from "../LogWrapper";
+import { CommentProcessor } from "../CommentProcessor";
+import { MessageSenderClient } from "../MatrixSender"
+import markdownit from "markdown-it";
+import { Script, createContext } from "vm";
+import { MatrixEvent } from "../MatrixEvent";
+
+export interface GenericHookConnectionState {
+    hookId: string;
+    transformationFunction?: string;
+}
+
+const log = new LogWrapper("GenericHookConnection");
+const md = new markdownit();
+
+/**
+ * Handles rooms connected to a github repo.
+ */
+export class GenericHookConnection implements IConnection {
+    static readonly CanonicalEventType = "uk.half-shot.matrix-github.generic.hook";
+
+    static readonly EventTypes = [
+        GenericHookConnection.CanonicalEventType,
+    ];
+
+    public get hookId() {
+        return this.state.hookId;
+    }
+
+    private transformationFunction?: Script;
+
+    constructor(public readonly roomId: string,
+        private state: GenericHookConnectionState,
+        private readonly stateKey: string,
+        private messageClient: MessageSenderClient) {
+            if (state.transformationFunction) {
+                this.transformationFunction = new Script(state.transformationFunction);
+            }
+        }
+
+    public isInterestedInStateEvent(eventType: string, stateKey: string) {
+        return GenericHookConnection.EventTypes.includes(eventType) && this.stateKey === stateKey;
+    }
+
+    public async onStateUpdate(stateEv: MatrixEvent<unknown>) {
+        const state = stateEv.content as GenericHookConnectionState;
+        if (state.transformationFunction) {
+            try {
+                this.transformationFunction = new Script(state.transformationFunction);
+            } catch (ex) {
+                await this.messageClient.sendMatrixText(this.roomId, 'Could not compile transformation function:' + ex);
+            }
+        }
+    }
+
+    public async onGenericHook(data: Record<string, unknown>) {
+        log.info(`onGenericHook ${this.roomId} ${this.hookId}`);
+        let content: string;
+        if (!this.transformationFunction) {
+            content = `Recieved webhook data:\n\n\`\`\`${JSON.stringify(data)}\`\`\``;
+        } else {
+            const context = createContext({data});
+            this.transformationFunction.runInContext(context);
+            if (context.result) {
+                content = `Recieved webhook: ${context.result}`;
+            } else {
+                content = `No content`;
+            }
+        }
+
+        return this.messageClient.sendMatrixMessage(this.roomId, {
+            msgtype: "m.notice",
+            body: content,
+            formatted_body: md.renderInline(content),
+            format: "org.matrix.custom.html",
+            "uk.half-shot.webhook_data": data,
+        });
+
+    }
+
+    public toString() {
+        return `GenericHookConnection ${this.hookId}`;
+    }
+}

--- a/src/Connections/GithubIssue.ts
+++ b/src/Connections/GithubIssue.ts
@@ -316,7 +316,7 @@ export class GitHubIssueConnection implements IConnection {
         }
     }
 
-    public onIssueStateChange(data?: any) {
+    public onIssueStateChange(data: unknown) {
         return this.syncIssueState();
     }
 

--- a/src/Connections/GithubRepo.ts
+++ b/src/Connections/GithubRepo.ts
@@ -288,7 +288,7 @@ export class GitHubRepoConnection implements IConnection {
         }
         const orgRepoName = event.repository.full_name;
         
-        const content = emoji.emojify(`${event.issue.user?.login} created new issue [${orgRepoName}#${event.issue.number}](${event.issue}): "${event.issue.title}"`);
+        const content = emoji.emojify(`${event.issue.user?.login} created new issue [${orgRepoName}#${event.issue.number}](${event.issue.html_url}): "${event.issue.title}"`);
         const { labelsHtml, labelsStr } = FormatUtil.formatLabels(event.issue.labels); 
         await this.as.botIntent.sendEvent(this.roomId, {
             msgtype: "m.notice",

--- a/src/Connections/GithubUserSpace.ts
+++ b/src/Connections/GithubUserSpace.ts
@@ -55,7 +55,8 @@ export class GitHubUserSpace implements IConnection {
             throw Error("Could not find repo");
         }
 
-        let avatarState: any|undefined;
+        // eslint-disable-next-line camelcase
+        let avatarState: {type: "m.room.avatar", state_key: "", content: { url: string}}|undefined;
         try {
             if (avatarUrl) {
                 const res = await axios.get(avatarUrl, {

--- a/src/Connections/GitlabRepo.ts
+++ b/src/Connections/GitlabRepo.ts
@@ -131,14 +131,6 @@ export class GitLabRepoConnection implements IConnection {
         });
     }
 
-    // public async onIssueCreated(event: IGitHubWebhookEvent) {
-
-    // }
-
-    // public async onIssueStateChange(event: IGitHubWebhookEvent) {
-
-    // }
-
     public toString() {
         return `GitHubRepo`;
     }

--- a/src/GithubBridge.ts
+++ b/src/GithubBridge.ts
@@ -137,8 +137,14 @@ export class GithubBridge {
             return new JiraProjectConnection(roomId, this.as, state.content, state.stateKey, this.commentProcessor, this.messageClient);
         }
 
-        if (GenericHookConnection.EventTypes.includes(state.type)) {
-            return new GenericHookConnection(roomId, state.content, state.stateKey, this.messageClient);
+        if (GenericHookConnection.EventTypes.includes(state.type) && this.config.generic?.enabled) {
+            return new GenericHookConnection(
+                roomId,
+                state.content,
+                state.stateKey,
+                this.messageClient,
+                this.config.generic.allowJsTransformationFunctions
+            );
         }
 
         return;

--- a/src/GithubBridge.ts
+++ b/src/GithubBridge.ts
@@ -1,36 +1,36 @@
+import { AdminRoom, BRIDGE_ROOM_TYPE, AdminAccountData } from "./AdminRoom";
 import { Appservice, IAppserviceRegistration, RichRepliesPreprocessor, IRichReplyMetadata, StateEvent, PantalaimonClient, MatrixClient } from "matrix-bot-sdk";
 import { BridgeConfig, GitLabInstance } from "./Config/Config";
-import { OAuthRequest, OAuthTokens, NotificationsEnableEvent, NotificationsDisableEvent,} from "./Webhooks";
+import { BridgeWidgetApi } from "./Widgets/BridgeWidgetApi";
 import { CommentProcessor } from "./CommentProcessor";
-import { MessageQueue, createMessageQueue } from "./MessageQueue/MessageQueue";
-import { AdminRoom, BRIDGE_ROOM_TYPE, AdminAccountData } from "./AdminRoom";
-import { UserTokenStore } from "./UserTokenStore";
-import { MatrixEvent, MatrixMemberContent, MatrixMessageContent } from "./MatrixEvent";
-import LogWrapper from "./LogWrapper";
-import { MessageSenderClient } from "./MatrixSender";
-import { UserNotificationsEvent } from "./Notifications/UserNotificationWatcher";
-import { RedisStorageProvider } from "./Stores/RedisStorageProvider";
-import { MemoryStorageProvider } from "./Stores/MemoryStorageProvider";
-import { NotificationProcessor } from "./NotificationsProcessor";
-import { IBridgeStorageProvider } from "./Stores/StorageProvider";
-import { retry } from "./PromiseUtil";
-import { IConnection, GitHubDiscussionSpace, GitHubDiscussionConnection, GitHubUserSpace
-} from "./Connections";
-import { GitHubRepoConnection } from "./Connections/GithubRepo";
+import { GetIssueResponse, GetIssueOpts } from "./Gitlab/Types"
+import { GenericHookConnection } from "./Connections/GenericHook";
+import { GithubInstance } from "./Github/GithubInstance";
 import { GitHubIssueConnection } from "./Connections/GithubIssue";
 import { GitHubProjectConnection } from "./Connections/GithubProject";
-import { GitLabRepoConnection } from "./Connections/GitlabRepo";
-import { GithubInstance } from "./Github/GithubInstance";
-import { IGitLabWebhookIssueStateEvent, IGitLabWebhookMREvent, IGitLabWebhookNoteEvent } from "./Gitlab/WebhookTypes";
-import { GitLabIssueConnection } from "./Connections/GitlabIssue";
-import { GetIssueResponse, GetIssueOpts } from "./Gitlab/Types"
+import { GitHubRepoConnection } from "./Connections/GithubRepo";
 import { GitLabClient } from "./Gitlab/Client";
-import { BridgeWidgetApi } from "./Widgets/BridgeWidgetApi";
-import { ProjectsGetResponseData } from "./Github/Types";
-import { NotifFilter, NotificationFilterStateContent } from "./NotificationFilters";
-import * as GitHubWebhookTypes from "@octokit/webhooks-types";
-import { JiraCommentCreatedEvent, JiraIssueEvent } from "./Jira/WebhookTypes";
+import { GitLabIssueConnection } from "./Connections/GitlabIssue";
+import { GitLabRepoConnection } from "./Connections/GitlabRepo";
+import { IBridgeStorageProvider } from "./Stores/StorageProvider";
+import { IConnection, GitHubDiscussionSpace, GitHubDiscussionConnection, GitHubUserSpace } from "./Connections";
+import { IGitLabWebhookIssueStateEvent, IGitLabWebhookMREvent, IGitLabWebhookNoteEvent } from "./Gitlab/WebhookTypes";
+import { JiraIssueEvent } from "./Jira/WebhookTypes";
 import { JiraProjectConnection } from "./Connections/JiraProject";
+import { MatrixEvent, MatrixMemberContent, MatrixMessageContent } from "./MatrixEvent";
+import { MemoryStorageProvider } from "./Stores/MemoryStorageProvider";
+import { MessageQueue, createMessageQueue } from "./MessageQueue/MessageQueue";
+import { MessageSenderClient } from "./MatrixSender";
+import { NotifFilter, NotificationFilterStateContent } from "./NotificationFilters";
+import { NotificationProcessor } from "./NotificationsProcessor";
+import { OAuthRequest, OAuthTokens, NotificationsEnableEvent, NotificationsDisableEvent, GenericWebhookEvent,} from "./Webhooks";
+import { ProjectsGetResponseData } from "./Github/Types";
+import { RedisStorageProvider } from "./Stores/RedisStorageProvider";
+import { retry } from "./PromiseUtil";
+import { UserNotificationsEvent } from "./Notifications/UserNotificationWatcher";
+import { UserTokenStore } from "./UserTokenStore";
+import * as GitHubWebhookTypes from "@octokit/webhooks-types";
+import LogWrapper from "./LogWrapper";
 
 const log = new LogWrapper("GithubBridge");
 
@@ -137,6 +137,10 @@ export class GithubBridge {
             return new JiraProjectConnection(roomId, this.as, state.content, state.stateKey, this.commentProcessor, this.messageClient);
         }
 
+        if (GenericHookConnection.EventTypes.includes(state.type)) {
+            return new GenericHookConnection(roomId, state.content, state.stateKey, this.messageClient);
+        }
+
         return;
     }
 
@@ -216,6 +220,11 @@ export class GithubBridge {
     private getConnectionsForJiraProject(projectId: string): JiraProjectConnection[] {
         return this.connections.filter((c) => (c instanceof JiraProjectConnection && c.projectId === projectId)) as JiraProjectConnection[];
     }
+
+    private getConnectionsForGenericWebhook(hookId: string): GenericHookConnection[] {
+        return this.connections.filter((c) => (c instanceof GenericHookConnection && c.hookId === hookId)) as GenericHookConnection[];
+    }
+
 
     public stop() {
         this.as.stop();
@@ -602,13 +611,25 @@ export class GithubBridge {
             log.info(`JIRA issue created for project ${data.issue.fields.project.id}, issue id ${data.issue.id}`);
             const projectId = data.issue.fields.project.id;
             const connections = this.getConnectionsForJiraProject(projectId);
-            console.log(data.issue.fields.project);
 
             connections.forEach(async (c) => {
                 try {
                     await c.onJiraIssueCreated(data);
                 } catch (ex) {
                     log.warn(`Failed to handle jira.issue_created:`, ex);
+                }
+            });
+        });
+    
+        this.queue.on<GenericWebhookEvent>("generic-webhook.event", async ({data}) => {
+            log.info(`Incoming generic hook ${data.hookId}`);
+            const connections = this.getConnectionsForGenericWebhook(data.hookId);
+
+            connections.forEach(async (c) => {
+                try {
+                    await c.onGenericHook(data.hookData);
+                } catch (ex) {
+                    log.warn(`Failed to handle generic-webhook.event:`, ex);
                 }
             });
         });

--- a/tests/AdminRoomTest.ts
+++ b/tests/AdminRoomTest.ts
@@ -24,7 +24,7 @@ describe("AdminRoom", () => {
 
         expect(intent.sentEvents[0]).to.deep.equal({
             roomId: ROOM_ID,
-            content: AdminRoom.helpMessage,
+            content: AdminRoom.helpMessage(),
         });
     });
 })

--- a/tests/FormatUtilTest.ts
+++ b/tests/FormatUtilTest.ts
@@ -2,6 +2,7 @@ import { FormatUtil } from "../src/FormatUtil";
 import { expect } from "chai";
 
 const SIMPLE_ISSUE = {
+    id: 123,
     number: 123,
     state: "open",
     title: "A simple title",
@@ -12,6 +13,7 @@ const SIMPLE_ISSUE = {
 };
 
 const SIMPLE_REPO = {
+    id: 123,
     description: "A simple description",
     full_name: "evilcorp/lab",
     html_url: "https://github.com/evilcorp/lab/issues/123",


### PR DESCRIPTION
This PR allows the bridge to handle any events sent to it, without knowing the format. Users can describe the transformation function of the data in state for the resulting message, which is executed in a secure JS context.